### PR TITLE
Added support for ScanImage 5.6, 5.7, 2019a, 2019b

### DIFF
--- a/scanreader/core.py
+++ b/scanreader/core.py
@@ -16,9 +16,12 @@ from .exceptions import ScanImageVersionError, PathnameError
 from . import scans
 
 _scans = {'5.1': scans.Scan5Point1, '5.2': scans.Scan5Point2, '5.3': scans.Scan5Point3,
-          '5.4': scans.Scan5Point4, '5.5': scans.Scan5Point5, '2016b': scans.Scan2016b,
-          '2017a': scans.Scan2017a, '2017b': scans.Scan2017b, '2018a': scans.Scan2018a,
-          '2018b': scans.Scan2018b}
+          '5.4': scans.Scan5Point4, '5.5': scans.Scan5Point5, 
+          '5.6': scans.Scan5Point6, '5.7': scans.Scan5Point7, 
+          '2016b': scans.Scan2016b, 
+          '2017a': scans.Scan2017a, '2017b': scans.Scan2017b, 
+          '2018a': scans.Scan2018a, '2018b': scans.Scan2018b,
+          '2019a': scans.Scan2019a, '2019b': scans.Scan2019b}
 
 def read_scan(pathnames, dtype=np.int16, join_contiguous=False):
     """ Reads a ScanImage scan.

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -11,11 +11,15 @@ BaseScan
             Scan5Point3
                 Scan5Point4
                 Scan5Point5
+                Scan5Point6
+                Scan5Point7
                 Scan2016b
                 Scan2017a
                 Scan2017b
                 Scan2018a
                 Scan2018b
+                Scan2019a
+                Scan2019b
     ScanMultiRoi
 """
 from tifffile import TiffFile
@@ -619,6 +623,14 @@ class Scan5Point5(Scan5Point3):
     """ScanImage 5.5"""
     pass
 
+class Scan5Point6(Scan5Point3):
+    """ScanImage 5.6"""
+    pass
+
+class Scan5Point7(Scan5Point3):
+    """ScanImage 5.7"""
+    pass
+
 
 class Scan2016b(Scan5Point3):
     """ ScanImage 2016b"""
@@ -641,7 +653,17 @@ class Scan2018a(Scan5Point3):
 
 
 class Scan2018b(Scan5Point3):
-    """ ScanImage 2018a"""
+    """ ScanImage 2018b"""
+    pass
+
+
+class Scan2019a(Scan5Point3):
+    """ ScanImage 2019a"""
+    pass
+
+
+class Scan2019b(Scan5Point3):
+    """ ScanImage 2019b"""
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = "Python TIFF Stack Reader for ScanImage 5 scans (including mu
 
 setup(
     name='scanreader',
-    version='0.4.10',
+    version='0.4.11',
     description="Reader for ScanImage 5 scans (including slow stacks and multiROI).",
     long_description=long_description,
     author='Erick Cobos',


### PR DESCRIPTION
Similar to commit ee8cfaf . Tested only superficially, but hopefully alright: http://scanimage.vidriotechnologies.com/display/SI2019/README