### PR TITLE
Added support for ScanImage 2020

### DIFF
--- a/scanreader/core.py
+++ b/scanreader/core.py
@@ -118,7 +118,7 @@ def get_scanimage_version(info):
     if version is None: 
         raise ScanImageVersionError('Could not find ScanImage version in the tiff header')
 
-    return version
+    return str(version)
 
 def is_scan_multiROI(info):
     """Looks whether the scan is multiROI in the tiff file headers.

--- a/scanreader/core.py
+++ b/scanreader/core.py
@@ -15,13 +15,16 @@ import re
 from .exceptions import ScanImageVersionError, PathnameError
 from . import scans
 
-_scans = {'5.1': scans.Scan5Point1, '5.2': scans.Scan5Point2, '5.3': scans.Scan5Point3,
+_scans = {
+          '5.1': scans.Scan5Point1, '5.2': scans.Scan5Point2, '5.3': scans.Scan5Point3,
           '5.4': scans.Scan5Point4, '5.5': scans.Scan5Point5, 
           '5.6': scans.Scan5Point6, '5.7': scans.Scan5Point7, 
           '2016b': scans.Scan2016b, 
           '2017a': scans.Scan2017a, '2017b': scans.Scan2017b, 
           '2018a': scans.Scan2018a, '2018b': scans.Scan2018b,
-          '2019a': scans.Scan2019a, '2019b': scans.Scan2019b}
+          '2019a': scans.Scan2019a, '2019b': scans.Scan2019b,
+          '2020':  scans.Scan2020
+        }
 
 def read_scan(pathnames, dtype=np.int16, join_contiguous=False):
     """ Reads a ScanImage scan.
@@ -100,11 +103,19 @@ def get_scanimage_version(info):
     Returns:
         A string. ScanImage version
     """
-    pattern = re.compile(r"SI.?\.VERSION_MAJOR = '(?P<version>.*)'")
-    match = re.search(pattern, info)
-    if match:
-        version = match.group('version')
-    else:
+    pattern_before_2020 = r"SI.?\.VERSION_MAJOR = '(?P<version>.*)'"
+    pattern_after_2020  = r"SI.?\.VERSION_MAJOR = (?P<version>.*)"
+
+    patterns = [pattern_before_2020, pattern_after_2020]
+
+    version = None
+    for pattern in patterns: 
+        p = re.compile(pattern)
+        match = re.search(p, info)
+        if match is not None: 
+            version = match.group('version') 
+
+    if version is None: 
         raise ScanImageVersionError('Could not find ScanImage version in the tiff header')
 
     return version

--- a/scanreader/core.py
+++ b/scanreader/core.py
@@ -114,11 +114,12 @@ def get_scanimage_version(info):
         match = re.search(p, info)
         if match is not None: 
             version = match.group('version') 
+            break
 
     if version is None: 
         raise ScanImageVersionError('Could not find ScanImage version in the tiff header')
 
-    return str(version)
+    return version
 
 def is_scan_multiROI(info):
     """Looks whether the scan is multiROI in the tiff file headers.

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -84,8 +84,17 @@ class BaseScan():
 
     @property
     def version(self):
-        match = re.search(r"SI.?\.VERSION_MAJOR = '(?P<version>.*)'", self.header)
-        version = match.group('version') if match else None
+        pattern_before_2020 = r"SI.?\.VERSION_MAJOR = '(?P<version>.*)'"
+        pattern_after_2020  = r"SI.?\.VERSION_MAJOR = (?P<version>.*)"
+
+        patterns = [pattern_before_2020, pattern_after_2020]
+
+        version = None
+        for pattern in patterns: 
+            p = re.compile(pattern)
+            match = re.search(p, self.header)
+            if match is not None: 
+                version = match.group('version') 
         return version
 
     @property

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -20,6 +20,7 @@ BaseScan
                 Scan2018b
                 Scan2019a
                 Scan2019b
+                Scan2020
     ScanMultiRoi
 """
 from tifffile import TiffFile
@@ -664,6 +665,10 @@ class Scan2019a(Scan5Point3):
 
 class Scan2019b(Scan5Point3):
     """ ScanImage 2019b"""
+    pass
+
+class Scan2020(Scan5Point3):
+    """ ScanImage 2020 and beyond"""
     pass
 
 

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -95,6 +95,7 @@ class BaseScan():
             match = re.search(p, self.header)
             if match is not None: 
                 version = match.group('version') 
+                break
         return version
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = "Python TIFF Stack Reader for ScanImage 5 scans (including mu
 
 setup(
     name='scanreader',
-    version='0.4.11',
+    version='0.4.12',
     description="Reader for ScanImage 5 scans (including slow stacks and multiROI).",
     long_description=long_description,
     author='Erick Cobos',


### PR DESCRIPTION
The latest scanimage tifs ran into an error (see https://github.com/atlab/scanreader/issues/11). 
The problem seemed to have been that the version string is no longer encoded as string but as integer value in the header of the tif, such that the version search itself ran into a problem in scanreader. 

I have updated the `version` matching such that it is backwards compatible and did a quick test on the recorded sample (see issue linked above) and older tifs. It seems to work fine, but I did not do an in depth validation (unit tests would be highly valuable I think). 

Some fields seem to be missing (e.g. `powerLimits`) and others might have been added. However, the core functionality seems to be intact. 

The fix follows previous PRs, for example https://github.com/atlab/scanreader/pull/10

